### PR TITLE
CreateTemp creates files with 0666 perms

### DIFF
--- a/adminconsole.go
+++ b/adminconsole.go
@@ -312,7 +312,7 @@ func AdminAcceptSubmission(argv []string) string {
 		Get file to upload to
 	*/
 
-	newJsonFile, err := os.CreateTemp("./current/", "*.json")
+	newJsonFile, err := CreateTemp("./current/", "*.json")
 	if err != nil {
 		return ".json file create temp error: " + err.Error()
 	}
@@ -555,7 +555,7 @@ func AdminAcceptEdit(argv []string) string {
 
 	var thePatch []byte = sub.Diff
 
-	PatchTempFile, err := os.CreateTemp("", "*")
+	PatchTempFile, err := CreateTemp("", "*")
 	if err != nil {
 		return "patch temp file error: " + err.Error()
 	}

--- a/apiv1.go
+++ b/apiv1.go
@@ -236,7 +236,7 @@ func APIv1Handler(w http.ResponseWriter, r *http.Request) {
 			Marshall sanitizedInputStr to a new tempfile in /submissions/
 		*/
 
-		file, err := os.CreateTemp("./submissions", "submission.*.unverified")
+		file, err := CreateTemp("./submissions", "submission.*.unverified")
 		if err != nil {
 			fmt.Println(err.Error())
 			SendJSONInternalErrorMessage(w, "500 Internal server error: "+err.Error())
@@ -439,7 +439,7 @@ func APIv1Handler(w http.ResponseWriter, r *http.Request) {
 
 		// write this to a temp file
 
-		tmpFileNewSub, err := os.CreateTemp("", "*.csv")
+		tmpFileNewSub, err := CreateTemp("", "*.csv")
 		defer os.Remove(tmpFileNewSub.Name())
 		if err != nil {
 			SendJSONErrorMessage(w, "csv temp file error: "+err.Error())
@@ -488,7 +488,7 @@ func APIv1Handler(w http.ResponseWriter, r *http.Request) {
 		out.Notes = eug.Notes
 		out.Diff = output
 
-		file, err := os.CreateTemp("./submissions", "edit.*.unverified")
+		file, err := CreateTemp("./submissions", "edit.*.unverified")
 		if err != nil {
 			fmt.Println(err.Error())
 			SendJSONInternalErrorMessage(w, "500 Internal server error: "+err.Error())

--- a/createLilypondIncipit.go
+++ b/createLilypondIncipit.go
@@ -11,7 +11,6 @@ import (
 	"bytes"
 	"context"
 	"fmt"
-	"os"
 	"os/exec"
 	"text/template"
 )
@@ -58,10 +57,10 @@ func CreateLilypondIncipit(originalScore, filename string) {
 
 	// save this to a temporary file
 
-	tmpFile, err := os.CreateTemp("", "lilyfile")
+	tmpFile, err := CreateTemp("", "lilyfile")
 	if err != nil {
 		tmpFile.Close()
-		fmt.Println("os.CreateTemp error", err)
+		fmt.Println("CreateTemp error", err)
 		return
 	}
 	defer tmpFile.Close()

--- a/createTempFileWithAllPerms.go
+++ b/createTempFileWithAllPerms.go
@@ -1,0 +1,23 @@
+package main
+
+import (
+	"os"
+)
+
+func CreateTemp(dir, pattern string) (file *os.File, err error) {
+	/*
+		os.CreateTemp creates files with bad perms.
+		This function wraps around os.CreateTemp and sets perms
+		to 0666 (will get masked by whatever perms ./wvlist
+		is running with). This way, all files will be editably by
+		the admin without sudo.
+	*/
+	file, err = os.CreateTemp(dir, pattern)
+	if err != nil {
+		return
+	}
+
+	err = file.Chmod(0666)
+
+	return
+}

--- a/lilypondSandbox.go
+++ b/lilypondSandbox.go
@@ -87,9 +87,9 @@ func LilypondSandbox(w http.ResponseWriter, r *http.Request) {
 
 		}
 
-		tmpFileIn, err := os.CreateTemp("./rootstatic/", "lilyfile_in.*.ly")
+		tmpFileIn, err := CreateTemp("./rootstatic/", "lilyfile_in.*.ly")
 		if err != nil {
-			fmt.Println("os.CreateTemp error", err)
+			fmt.Println("CreateTemp error", err)
 			return
 		}
 
@@ -101,9 +101,9 @@ func LilypondSandbox(w http.ResponseWriter, r *http.Request) {
 
 		go deleteFileFunc(tmpFileIn)
 
-		tmpFileOut, err := os.CreateTemp("./rootstatic/", "lilyfile_out.*")
+		tmpFileOut, err := CreateTemp("./rootstatic/", "lilyfile_out.*")
 		if err != nil {
-			fmt.Println("os.CreateTemp error", err)
+			fmt.Println("CreateTemp error", err)
 			return
 		}
 

--- a/smtpStuff.go
+++ b/smtpStuff.go
@@ -118,7 +118,7 @@ func Apiv1SentSmtpEmailForEditUgly(name, email, id, password string, info V1Uplo
 	/*
 		Write the info json file and diff to temp files and send them with the email
 	*/
-	tmpFileInfo, err := os.CreateTemp("", "*.json")
+	tmpFileInfo, err := CreateTemp("", "*.json")
 	if err != nil {
 		return err
 	}
@@ -132,7 +132,7 @@ func Apiv1SentSmtpEmailForEditUgly(name, email, id, password string, info V1Uplo
 	tmpFileInfo.Close()
 	defer os.Remove(tmpFileInfo.Name())
 
-	tmpFileDiff, err := os.CreateTemp("", "*.patch")
+	tmpFileDiff, err := CreateTemp("", "*.patch")
 	if err != nil {
 		return err
 	}
@@ -184,7 +184,7 @@ func Apiv1SendSmtpEmailForSubmitUgly(san V1UploadUglySanitizedInput, fileIndex s
 		to temp file and send that.
 	*/
 
-	tmpFile, err := os.CreateTemp("", "*.json")
+	tmpFile, err := CreateTemp("", "*.json")
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
_For an upcoming major update._

Previously, some files created were made by `os.CreateTemp` which made files with 0600 permissions, which meant the administrator was required to use `sudo` to access and modify these files. `CreateTemp` makes a file in the same way (so that it is guaranteed to have a unique filename) and is meant to be used in place of os.CreateTemp.