### PR TITLE
fix #7 and check for exact number of required args for admin commands

### DIFF
--- a/adminconsole.go
+++ b/adminconsole.go
@@ -203,7 +203,7 @@ func AdminGetAnyFileTypeFromSnippet(id string, filetype string) (*os.DirEntry, s
 }
 
 func AdminViewSubmission(argv []string) string {
-	if len(argv) < 2 {
+	if len(argv) != 2 {
 		return "vsub <id>"
 	}
 
@@ -257,7 +257,7 @@ func AdminViewSubmission(argv []string) string {
 }
 
 func AdminAcceptSubmission(argv []string) string {
-	if len(argv) < 2 {
+	if len(argv) != 2 && len(argv) != 3 {
 		return "asub <id>"
 	}
 
@@ -268,7 +268,7 @@ func AdminAcceptSubmission(argv []string) string {
 	}
 
 	submission := *submissionp
-	if len(argv) < 3 || argv[2] != "confirm" {
+	if len(argv) != 3 || argv[2] != "confirm" {
 		return "About to accept " + submission.Name() + "\nAre you sure you want to do this? Type asub <id> confirm"
 	}
 
@@ -505,7 +505,7 @@ func GetAcceptEditPatchCommand(file, patch string) *exec.Cmd {
 }
 
 func AdminAcceptEdit(argv []string) string {
-	if len(argv) < 2 {
+	if len(argv) != 2 && len(argv) != 3 {
 		return "asub <id>"
 	}
 
@@ -723,6 +723,10 @@ func AdminViewEdit(argv []string) string {
 }
 
 func AdminRejectSubmission(argv []string) string {
+	if len(argv) != 2 {
+		return "Error: no <id> specified.\n\nrsub <id>"
+	}
+
 	id := argv[1]
 	submissionp, errorMessage := AdminGetSubmissionFromSnippet(id)
 	if errorMessage != "" {


### PR DESCRIPTION
Previousy, daemon would panic if served an `rsub` admin command without any args.

All admin commands now check for exact number of args instead of checking for equal to or greater than required amount (and silently ignoring those beyond which are required).